### PR TITLE
add delete() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ return the currently set `value` for `key`. may be null.
 
 Set a new value. this will trigger a write to be performed (at some point)
 
+### store.delete(key)
+
+Delete a key-value from the store.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -34,5 +34,7 @@ module.exports = function (dir, codec, keyCodec) {
     try { value = codec.encode(value) }
     catch (err) { return cb(err) }
     atomic.writeFile(toPath(id), value, cb)
+  }, function del (id, cb) {
+    atomic.delete(toPath(id), cb)
   })
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/arj03/key-value-file-store.git"
   },
   "dependencies": {
-    "atomic-file-rw": "^0.2.2"
+    "atomic-file-rw": "^0.3.0"
   },
   "devDependencies": {
     "base64-url": "^2.3.3",

--- a/test/index.js
+++ b/test/index.js
@@ -89,3 +89,16 @@ tape('set fires ensure', function (t) {
 
   t.end()
 })
+
+tape('delete', function (t) {
+  var mock = Mock()
+  var store = Store(mock.read, mock.write)
+
+  store.set('foo', 123)
+  t.equals(store.get('foo'), 123)
+
+  store.delete('foo')
+  t.equals(store.get('foo'), undefined)
+
+  t.end()
+})


### PR DESCRIPTION
Context: in ssb-ebt we need to delete persistent state for a given feed after that feed's messages are deleted from the log. For that, we'll need to support deletion in key-value-file-store.